### PR TITLE
(WIP) Pin version

### DIFF
--- a/codecov
+++ b/codecov
@@ -2,7 +2,7 @@
 
 set -e +o pipefail
 
-VERSION="tbd"
+VERSION="1b98dd4"
 
 url="https://codecov.io"
 url_o=""


### PR DESCRIPTION
This PR allows using Edraak's hosted codecov bash file.

So instead of:
```
$ curl -s https://codecov.io/bash | bash
```

We get to use:

```
$ curl https://edraak.github.io/codecov-bash/codecov | bash
```

In my opinion this much better than waiting for someone to hack codecov and executing arbitrary code on my server.

----

Keep this PR dangling, this is here for reference only.